### PR TITLE
Fixed proto field name in integration: clientInfo -> client_info

### DIFF
--- a/custom_components/hassmic/hassmic.py
+++ b/custom_components/hassmic/hassmic.py
@@ -47,7 +47,7 @@ class HassMic:
             async with asyncio.timeout(2):
                 m = await HassMic.recv_message(reader)
                 if (w := betterproto.which_one_of(m, "msg"))[0] == "client_info":
-                    if (uuid := w[1].get("uuid")) is not None:
+                    if (uuid := w[1].uuid) is not None:
                         return uuid
                 raise BadHassMicClientInfoException
         # Finally is executed regardless of result

--- a/custom_components/hassmic/hassmic.py
+++ b/custom_components/hassmic/hassmic.py
@@ -46,7 +46,7 @@ class HassMic:
         try:
             async with asyncio.timeout(2):
                 m = await HassMic.recv_message(reader)
-                if (w := betterproto.which_one_of(m, "msg"))[0] == "clientInfo":
+                if (w := betterproto.which_one_of(m, "msg"))[0] == "client_info":
                     if (uuid := w[1].get("uuid")) is not None:
                         return uuid
                 raise BadHassMicClientInfoException


### PR DESCRIPTION
I needed to make this change for the latest version of the integration and android APK to communicate with each other:

The received message was:
```
ClientMessage(
ping=Ping(),
client_info=ClientInfo(version='0.9.1', uuid='XXXXX'), audio_data=AudioData(data=b''),
client_event=ClientEvent(media_player_state_change=MediaPlayerStateChange(player=0, new_state=0),
media_player_volume_change=MediaPlayerVolume(player=0, volume=0.0),
device_volume_change=DeviceVolume(volume=0.0),
log=Log(log_text='')),
saved_settings=SavedSettings(announce_volume=0.0, playback_volume=0.0))
```

Thanks for all the work on this useful project!