### PR TITLE
Create continue_conversation.py for continue conversation switch

### DIFF
--- a/custom_components/hassmic/switch/continue_conversation.py
+++ b/custom_components/hassmic/switch/continue_conversation.py
@@ -1,0 +1,68 @@
+"""Provides the switch for controlling continue conversation."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.switch import (
+    ENTITY_ID_FORMAT,
+    SwitchDeviceClass,
+    SwitchEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .. import util
+from homeassistant.components.assist_pipeline.pipeline import PipelineStage
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ContinueConversationSwitch(SwitchEntity):
+    """Switch to control the continue conversation feature."""
+
+    _attr_is_on = False
+    _attr_should_poll = False
+    _attr_device_class = SwitchDeviceClass.SWITCH
+    _attr_name = "Continue Conversation"  # Set the name directly here
+
+    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+        """Initialize the Continue Conversation switch."""
+        super().__init__()
+        self.hass = hass
+        util.InitializeEntity(self, ENTITY_ID_FORMAT, hass, config_entry)
+
+        # Ensure the initial pipeline stage matches the default state of the switch
+        self._update_pipeline_stage()
+
+    @property
+    def icon(self) -> str:
+        """Return the icon of the switch."""
+        return "mdi:toggle-switch"
+
+    @property
+    def hassmic_entity_name(self) -> str:
+        """Return the entity name for the switch."""
+        return "continue_conversation"
+
+    def turn_on(self, **kwargs) -> None:
+        """Turn the switch on."""
+        self._attr_is_on = True
+        self._update_pipeline_stage()
+        self.schedule_update_ha_state()
+
+    def turn_off(self, **kwargs) -> None:
+        """Turn the switch off."""
+        self._attr_is_on = False
+        self._update_pipeline_stage()
+        self.schedule_update_ha_state()
+
+    def _update_pipeline_stage(self) -> None:
+        """Update the start stage of the pipeline based on switch state."""
+        if self._attr_is_on:
+            _LOGGER.debug("Setting pipeline start stage to STT.")
+            self.hass.data["pipeline_start_stage"] = PipelineStage.STT
+        else:
+            _LOGGER.debug("Setting pipeline start stage to WAKE_WORD.")
+            self.hass.data["pipeline_start_stage"] = PipelineStage.WAKE_WORD
+


### PR DESCRIPTION
Add continue conversation switch.  Changes must also be made in the _init_.py files from the switch directory, and in the util.py file. To be able to use continuous conversation in Hassmic, a switch can be used to choose where to start the pipeline, when it is off, it starts the pipeline from WAKE-WORD, and when it is on, it starts from STT-START. To use this, you also need an automation that switches on the continue conversation switch and, when the answer comes from HA, switches the microphone off, then turns the microphone back on for Stt-listening. 
This is an automation model, but it still needs to be finished. The problem is that you cannot use only the Simple_state sensor because there are some stages of the pipeline that run very quickly one after the other and then the automation fails to activate because the sensor does not expose all the stages of the pipeline every time. That is why it is necessary to use the Simple State, the Pipeline stage  and the Wake sensors. For example, I need tts-speaking but it appears very little because immediately wake_word-listening appears and the automation fails to take over stt-listening. I would need WAKE_WORD_END, but this does not appear because STT-START appears immediately.I disabled Wake_word-listening from the Hassmic integration, because I need tts-speaking and tts-finished, which did not appear because of wake_word-listening. That is why two sensors should be configured to alternatively expose all the pipeline stages we need.
```
alias: ViewAssist birou continue conversation
description: ""
triggers:
  - trigger: state
    entity_id:
      - sensor.viewassist_birou_simple_state
    to: tts-speaking
  - trigger: state
    entity_id:
      - sensor.viewassist_birou_simple_state
    to: intent-processing
conditions: []
actions:
  - action: switch.turn_on
    metadata: {}
    data: {}
    target:
      entity_id: switch.viewassist_birou_continue_conversation
  - action: switch.turn_off
    metadata: {}
    data: {}
    target:
      entity_id: switch.viewassist_birou_microphone
  - wait_for_trigger:
      - trigger: state
        entity_id:
          - sensor.viewassist_birou_simple_state
        to: tts-finished
  - action: switch.turn_on
    metadata: {}
    data: {}
    target:
      entity_id: switch.viewassist_birou_microphone
  - wait_for_trigger:
      - trigger: template
        value_template: >-
          {{ states('sensor.viewassist_birou_pipeline_state') != 'stt-vad-end'
          }}
        for:
          hours: 0
          minutes: 0
          seconds: 30
    timeout:
      hours: 0
      minutes: 0
      seconds: 0
  - action: switch.turn_off
    metadata: {}
    data: {}
    target:
      entity_id: switch.viewassist_birou_continue_conversation
mode: single
```