### PR TITLE
Update simple_state.py FOR TTS-FINISHED STATUS

### DIFF
--- a/custom_components/hassmic/sensor/simple_state.py
+++ b/custom_components/hassmic/sensor/simple_state.py
@@ -1,20 +1,20 @@
 """Defines the `simple_state` sensor"""
 
 from __future__ import annotations
-
+import asyncio
 import logging
-
+import io
 from homeassistant.components.assist_pipeline.pipeline import (
     PipelineEvent,
     PipelineEventType,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-
+from mutagen.mp3 import MP3
 from . import base
-
+from homeassistant.helpers.network import get_url
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 _LOGGER = logging.getLogger(__name__)
-
 
 class SimpleState(base.SensorBase):
     """Defines the 'simple state' sensor, for use with view assist."""
@@ -29,7 +29,7 @@ class SimpleState(base.SensorBase):
 
     def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
         super().__init__(hass, config_entry)
-
+        self.tts_duration = 0
     def on_pipeline_event(self, event: PipelineEvent):
         """Handle a pipeline event."""
 
@@ -43,14 +43,25 @@ class SimpleState(base.SensorBase):
                 case PipelineEventType.ERROR:
                     return "error-error"
                 case PipelineEventType.WAKE_WORD_START:
-                    return "wake_word-listening"
+                    asyncio.create_task(self._handle_delayed_state("wake_word-listening"))
+                    return None
+                case PipelineEventType.WAKE_WORD_END:
+                    return "wake_word-detected"
                 case PipelineEventType.STT_START:
-                    return "stt-listening"
+                    asyncio.create_task(self._handle_delayed_state("stt-listening"))
+                    return None
                 case PipelineEventType.INTENT_START:
                     return "intent-processing"
                 case PipelineEventType.TTS_START:
                     return "tts-generating"
                 case PipelineEventType.TTS_END:
+                    # Get the TTS URL and events to pass them to _handle_tts_end
+                    tts = event.data["tts_output"]
+                    tts_url = tts["url"]
+                    events = event.data.get("events", {})
+
+                    # Call _handle_tts_end to get the duration and trigger the popup
+                    asyncio.create_task(self._handle_tts_end(tts_url, events))  # Call service to handle TTS end
                     return "tts-speaking"
                 case _:
                     return None
@@ -58,6 +69,63 @@ class SimpleState(base.SensorBase):
         s = getSimpleState(event.type)
         if s is not None:
             self._attr_native_value = s
+            
+    async def get_tts_duration(self, hass: HomeAssistant, tts_url: str) -> float:
+        try:
+            if tts_url.startswith('/'):
+                base_url = get_url(hass)
+                full_url = f"{base_url}{tts_url}"
+            else:
+                full_url = tts_url
+
+            session = async_get_clientsession(hass)
+            async with session.get(full_url) as response:
+                if response.status != 200:
+                    _LOGGER.error(f"Failed to fetch TTS audio: HTTP {response.status}")
+                    return 0
+
+                content = await response.read()
+
+            audio = MP3(io.BytesIO(content))
+            return audio.info.length
+        except Exception as e:
+            _LOGGER.error(f"Error getting TTS duration: {e}")
+            return 0
+            
+    async def _handle_tts_end(self, tts_url: str, events: dict):
+        """Handle the end of TTS and store its duration."""
+        try:
+            # Obține durata TTS și o stochează doar pentru sesiunea curentă
+            duration = await self.get_tts_duration(self.hass, tts_url)
+            self.tts_duration = duration  # Setează durata pentru stări dependente
+            if events and PipelineEventType.TTS_END in events:
+                events[PipelineEventType.TTS_END]["data"]["tts_duration"] = duration
+            _LOGGER.debug(f"Stored TTS duration: {duration} seconds")
+            # Așteaptă durata înainte de a marca TTS ca terminat
+            await asyncio.sleep(duration - 0.5)
+            self._attr_native_value = "tts-finished"
+            self.async_write_ha_state()
+
+        except Exception as e:
+            _LOGGER.error(f"Error in _handle_tts_end: {e}")
+
+    async def _handle_delayed_state(self, state: str):
+        """Handle state changes with an additional delay."""
+        try:
+            await asyncio.sleep(0.5)
+            # Aplică întârzierea doar dacă există o valoare pentru `tts_duration`
+            if self.tts_duration > 0:
+                await asyncio.sleep(self.tts_duration)
+            self._attr_native_value = state
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.error(f"Error in _handle_delayed_state: {e}")
+        finally:
+            # Nu resetați `tts_duration` în mod direct, doar în condiții controlate
+            if state in ["wake_word-listening", "stt-listening"]:
+                _LOGGER.debug(f"Resetting tts_duration after state: {state}")
+                self.tts_duration = 0
+
 
 
 # vim: set ts=4 sw=4:


### PR DESCRIPTION
Hello. Congratulations on what you've been able to do with this integration. In order to be able to properly implement Hassmic integration in the ViewAssist project, I made some changes to the code.
1. **Tts-listening state implementation**
 One of the things needed to use this integration is to be as precise as possible when the tts message actually finishes playing because TTS_END marks when the message is sent to the player and not when it finishes playing. That's why I took this implementation from the [StreamAssist integration](https://github.com/AlexxIT/StreamAssist/issues/31) and looked for the best way to implement it in Hassmic. Practically, when the TTS_END event is executed, the URL of the tts is taken and using mutagen.mp3 to calculate the effective duration of the message. Then in the SimpeState sensor I put a new state tts-finished. 
 2. **Correcting the publication order of stt-speaking, stt-listening, wake_word-listening/stt-listening statuses**
 There is a problem though with the fact that the wake_word-listening state fires before the message finishes playing and at the end it remains as the last state `tts-finished` and not `wake_word-listening`. That's why I modified the code to respect the order of publishing the statuses: `stt-speaking`, `stt-listening`and at the end`wake_word-listening` or `stt-listening`, depending on how the continue conversation switch is set. Practically, I added a delay in the publication of wake_word-listening or stt-listening statuses until the tts message is finished playing. This does not affect the functionality of the satellite in any way because the `Simple state sensor` is just a sensor made especially for the View Assist project. Listening to the wake word starts immediately after TTS-END, but in order for the avatar to remain talking until the end of the message playback, this is necessary.
3. **Continue conversation switch**
I also added a switch to enable continue conversation. Changes must also be made in the `_init_.py` file from the` switch` directory,  in the `pipeline_manager.py` file and add `continue_conversation.py` . To be able to use continuous conversation in Hassmic, a switch can be used to choose where to start the pipeline, from `WAKE-WORD` or from `STT-START`. In the continue_conversatin switch code, you can set how many seconds to wait for the next command until it switches back to wake word detection. From what I noticed, after 9 seconds it is no longer in the listening state and the pipeline resumes from the start.
```
            done, pending = await asyncio.wait(
                [vad_task, error_task],
                timeout=9,
                return_when=asyncio.FIRST_COMPLETED,
            ) ```
 Because `stt-listening` starts before the tts message is finished playing, I made an automation in the `continue_conversation switch` code that mutes the microphone between the `tts-speaking` and `tts-listening` statuses of the `simple_state sensor`. Because I failed to import the `simple_state sensor` internally in the `continue_conversation switch`, I chose to import it from the home assistant, but I think it would work better if you managed to import it directly from the hassmic integration.
 
- Optionally  you can use uith that the `custom_responses blueprint` which gives an answer after detecting the wake word (Ex: yes i'm listening) or if you say `ok nabu` twice or when it is in `continue_conversation mode` and you don't realize that the satellite is actually waiting for the command and not the wake word.
```
blueprint:
  name: Viewassist Custom Responses
  description: Automation for custom responses in Viewassist with selectable media content ID, media player, microphone, and custom wake words.
  domain: automation
  input:
    trigger_entity:
      name: Trigger Entity
      description: Microphone entity sensor of satellite ex. sensor.viewassist_office_simple_state
      selector:
        entity:
          domain: sensor
    media_player:
      name: Media Player
      description: Select the media player to use
      selector:
        entity:
          domain: media_player
    microphone_switch:
      name: Microphone Switch
      description: Select the microphone switch to turn off and on
      selector:
        entity:
          domain: switch
    media_content_id:
      name: Media Content ID
      description: The media content ID to play (optional, with a default message)
      default: "media-source://tts/edge_tts?message={{ ['how can I help you', 'yes, i`m listening', 'how can assist you'] | random }}&language=en-US-ChristopherNeural"
      selector:
        text: {}
    custom_wake_words:
      name: Custom Wake Words
      description: Add custom wake words (e.g., 'ok nabu'). Add multiple values if needed.
      default: ["ok nabu", "ok naboo", "okay naboo"]
      selector:
        object: {}
    conversation_response:
      name: Set Conversation Response
      description: The response text for custom wake words
      default: "say please"
      selector:
        text: {}

trigger:
  - platform: state
    entity_id: !input "trigger_entity"
    to: wake_word-detected
    id: wake_word_detected
  - platform: conversation
    command: !input "custom_wake_words"
    id: custom_wake_word_detected

condition: []

action:
  - choose:
      - conditions:
          - condition: trigger
            id: wake_word_detected
        sequence:
          - service: switch.turn_off
            target:
              entity_id: !input "microphone_switch"
          - service: media_player.play_media
            target:
              entity_id: !input "media_player"
            data:
              media_content_id: !input "media_content_id"
              media_content_type: provider
              announce: true
          - wait_for_trigger:
              - platform: state
                entity_id: !input "media_player"
                to: idle
            timeout:
              hours: 0
              minutes: 0
              seconds: 1
              milliseconds: 500
          - service: switch.turn_on
            target:
              entity_id: !input "microphone_switch"
      - conditions:
          - condition: trigger
            id: custom_wake_word_detected
        sequence:
          - service: media_player.play_media
            target:
              entity_id: !input "media_player"
            data:
              media_content_id: !input "media_content_id"
              media_content_type: provider
              announce: true
          - set_conversation_response: !input "conversation_response"
            enabled: true

mode: single
```