### PR TITLE
Add tts-finished state to simple_state sensor, continue_conversation switch and custom_responses_blueprint

### DIFF
--- a/custom_components/hassmic/custom_responses_blueprint.yaml
+++ b/custom_components/hassmic/custom_responses_blueprint.yaml
@@ -1,0 +1,96 @@
+blueprint:
+  name: Viewassist Custom Responses
+  description: Automation for custom responses in Viewassist with selectable media content ID, media player, microphone, and custom wake words.
+  domain: automation
+  input:
+    trigger_entity:
+      name: Trigger Entity
+      description: Microphone entity sensor of satellite ex. sensor.viewassist_office_simple_state
+      selector:
+        entity:
+          domain: sensor
+    media_player:
+      name: Media Player
+      description: Select the media player to use
+      selector:
+        entity:
+          domain: media_player
+    microphone_switch:
+      name: Microphone Switch
+      description: Select the microphone switch to turn off and on
+      selector:
+        entity:
+          domain: switch
+    media_content_id:
+      name: Media Content ID
+      description: The media content ID to play (optional, with a default message)
+      default: "media-source://tts/edge_tts?message={{ ['how can I help you', 'yes, i`m listening', 'how can assist you'] | random }}&language=en-US-ChristopherNeural"
+      selector:
+        text: {}
+    custom_wake_words:
+      name: Custom Wake Words
+      description: Add custom wake words (e.g., 'ok nabu'). Add multiple values if needed.
+      default: ["ok nabu", "ok naboo", "okay naboo"]
+      selector:
+        object: {}
+    conversation_response:
+      name: Set Conversation Response
+      description: The response text for custom wake words
+      default: "say please"
+      selector:
+        text: {}
+
+trigger:
+  - platform: state
+    entity_id: !input "trigger_entity"
+    to: wake_word-detected
+    id: wake_word_detected
+  - platform: conversation
+    command: !input "custom_wake_words"
+    id: custom_wake_word_detected
+
+condition: []
+
+action:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: wake_word_detected
+        sequence:
+          - service: switch.turn_off
+            target:
+              entity_id: !input "microphone_switch"
+          - service: media_player.play_media
+            target:
+              entity_id: !input "media_player"
+            data:
+              media_content_id: !input "media_content_id"
+              media_content_type: provider
+              announce: true
+          - wait_for_trigger:
+              - platform: state
+                entity_id: !input "media_player"
+                to: idle
+            timeout:
+              hours: 0
+              minutes: 0
+              seconds: 1
+              milliseconds: 500
+          - service: switch.turn_on
+            target:
+              entity_id: !input "microphone_switch"
+      - conditions:
+          - condition: trigger
+            id: custom_wake_word_detected
+        sequence:
+          - service: media_player.play_media
+            target:
+              entity_id: !input "media_player"
+            data:
+              media_content_id: !input "media_content_id"
+              media_content_type: provider
+              announce: true
+          - set_conversation_response: !input "conversation_response"
+            enabled: true
+
+mode: single

--- a/custom_components/hassmic/pipeline_manager.py
+++ b/custom_components/hassmic/pipeline_manager.py
@@ -119,6 +119,13 @@ class PipelineManager:
         self._should_close = False
         while not self._should_close:
             try:
+                # Determines the startup stage based on the state of the continue_conversation switch
+                start_stage = (
+                    PipelineStage.STT
+                    if self._hass.data.get("pipeline_start_stage") == PipelineStage.STT
+                    else PipelineStage.WAKE_WORD
+                )
+
                 await assist_pipeline.async_pipeline_from_audio_stream(
                     hass=self._hass,
                     context=Context(),
@@ -132,8 +139,9 @@ class PipelineManager:
                         sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
                         channel=stt.AudioChannels.CHANNEL_MONO,
                     ),
-                    start_stage=PipelineStage.WAKE_WORD,
+                    start_stage=start_stage,
                     device_id=self._device.id,
+                    conversation_id="123456789",
                 )
 
                 _LOGGER.debug("Pipeline finished, starting over")

--- a/custom_components/hassmic/sensor/simple_state.py
+++ b/custom_components/hassmic/sensor/simple_state.py
@@ -1,20 +1,20 @@
 """Defines the `simple_state` sensor"""
 
 from __future__ import annotations
-
+import asyncio
 import logging
-
+import io
 from homeassistant.components.assist_pipeline.pipeline import (
     PipelineEvent,
     PipelineEventType,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-
+from mutagen.mp3 import MP3
 from . import base
-
+from homeassistant.helpers.network import get_url
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 _LOGGER = logging.getLogger(__name__)
-
 
 class SimpleState(base.SensorBase):
     """Defines the 'simple state' sensor, for use with view assist."""
@@ -29,7 +29,7 @@ class SimpleState(base.SensorBase):
 
     def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
         super().__init__(hass, config_entry)
-
+        self.tts_duration = 0
     def on_pipeline_event(self, event: PipelineEvent):
         """Handle a pipeline event."""
 
@@ -43,14 +43,25 @@ class SimpleState(base.SensorBase):
                 case PipelineEventType.ERROR:
                     return "error-error"
                 case PipelineEventType.WAKE_WORD_START:
-                    return "wake_word-listening"
+                    asyncio.create_task(self._handle_delayed_state("wake_word-listening"))
+                    return None
+                case PipelineEventType.WAKE_WORD_END:
+                    return "wake_word-detected"
                 case PipelineEventType.STT_START:
-                    return "stt-listening"
+                    asyncio.create_task(self._handle_delayed_state("stt-listening"))
+                    return None
                 case PipelineEventType.INTENT_START:
                     return "intent-processing"
                 case PipelineEventType.TTS_START:
                     return "tts-generating"
                 case PipelineEventType.TTS_END:
+                    # Get the TTS URL and events to pass them to _handle_tts_end
+                    tts = event.data["tts_output"]
+                    tts_url = tts["url"]
+                    events = event.data.get("events", {})
+
+                    # Call _handle_tts_end to get the duration and trigger the popup
+                    asyncio.create_task(self._handle_tts_end(tts_url, events))  # Call service to handle TTS end
                     return "tts-speaking"
                 case _:
                     return None
@@ -58,6 +69,61 @@ class SimpleState(base.SensorBase):
         s = getSimpleState(event.type)
         if s is not None:
             self._attr_native_value = s
+    async def get_tts_duration(self, hass: HomeAssistant, tts_url: str) -> float:
+        try:
+            if tts_url.startswith('/'):
+                base_url = get_url(hass)
+                full_url = f"{base_url}{tts_url}"
+            else:
+                full_url = tts_url
+
+            session = async_get_clientsession(hass)
+            async with session.get(full_url) as response:
+                if response.status != 200:
+                    _LOGGER.error(f"Failed to fetch TTS audio: HTTP {response.status}")
+                    return 0
+
+                content = await response.read()
+
+            audio = MP3(io.BytesIO(content))
+            return audio.info.length
+        except Exception as e:
+            _LOGGER.error(f"Error getting TTS duration: {e}")
+            return 0
+    async def _handle_tts_end(self, tts_url: str, events: dict):
+        """Handle the end of TTS and store its duration."""
+        try:
+            # Obține durata TTS și o stochează doar pentru sesiunea curentă
+            duration = await self.get_tts_duration(self.hass, tts_url)
+            self.tts_duration = duration  # Setează durata pentru stări dependente
+            if events and PipelineEventType.TTS_END in events:
+                events[PipelineEventType.TTS_END]["data"]["tts_duration"] = duration
+            _LOGGER.debug(f"Stored TTS duration: {duration} seconds")
+            # Așteaptă durata înainte de a marca TTS ca terminat
+            await asyncio.sleep(duration - 0.5)
+            self._attr_native_value = "tts-finished"
+            self.async_write_ha_state()
+
+        except Exception as e:
+            _LOGGER.error(f"Error in _handle_tts_end: {e}")
+
+    async def _handle_delayed_state(self, state: str):
+        """Handle state changes with an additional delay."""
+        try:
+            await asyncio.sleep(0.5)
+            # Aplică întârzierea doar dacă există o valoare pentru `tts_duration`
+            if self.tts_duration > 0:
+                await asyncio.sleep(self.tts_duration)
+            self._attr_native_value = state
+            self.async_write_ha_state()
+        except Exception as e:
+            _LOGGER.error(f"Error in _handle_delayed_state: {e}")
+        finally:
+            # Nu resetați `tts_duration` în mod direct, doar în condiții controlate
+            if state in ["wake_word-listening", "stt-listening"]:
+                _LOGGER.debug(f"Resetting tts_duration after state: {state}")
+                self.tts_duration = 0
+
 
 
 # vim: set ts=4 sw=4:

--- a/custom_components/hassmic/switch/__init__.py
+++ b/custom_components/hassmic/switch/__init__.py
@@ -7,6 +7,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .microphone import Microphone
+from .continue_conversation import ContinueConversationSwitch
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -15,7 +16,6 @@ ALL_SWITCH_TYPES = [
     Microphone,
 ]
 
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -23,9 +23,13 @@ async def async_setup_entry(
 ) -> None:
     """Initialize hassmic config entry for switches."""
 
-    async_add_entities(
-        [switch_type(hass, config_entry) for switch_type in ALL_SWITCH_TYPES]
-    )
+    microphone = Microphone(hass, config_entry)
+    continue_conversation = ContinueConversationSwitch(hass, config_entry, microphone)
 
+    async_add_entities([
+        microphone,
+        continue_conversation,
+        *[switch_type(hass, config_entry) for switch_type in ALL_SWITCH_TYPES if switch_type is not Microphone]
+    ])
 
 # vim: set ts=4 sw=4:

--- a/custom_components/hassmic/switch/continue_conversation.py
+++ b/custom_components/hassmic/switch/continue_conversation.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from homeassistant.components.assist_pipeline.pipeline import PipelineEvent, PipelineEventType
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.event import async_track_state_change
+from homeassistant.components import sensor
+from . import base
+from . import microphone
+
+_LOGGER = logging.getLogger(__name__)
+
+class PipelineStage:
+    """Defines pipeline stages."""
+    STT = "stt"
+    WAKE_WORD = "wake_word"
+
+
+class ContinueConversationSwitch(base.SwitchBase):
+    """Defines a switch for controlling 'Continue Conversation'."""
+
+    @property
+    def hassmic_entity_name(self):
+        return "continue_conversation"
+
+    @property
+    def icon(self):
+        return "mdi:chat"
+
+    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry, microphone: Microphone) -> None:
+        super().__init__(hass, config_entry)
+        self._attr_is_on = False
+        self.microphone = microphone
+        self.config_entry = config_entry
+        self._vad_start_detected = asyncio.Event()  # Event to detect VAD_START within the monitoring window.
+        asyncio.create_task(self._initialize_simple_state_sensor())
+
+    async def _initialize_simple_state_sensor(self):
+        """Wait for the simple_state sensor to become available."""
+        max_retries = 30  # 30 seconds, check every second
+        initial_entity_id = f"sensor.{self.config_entry.title.replace(' ', '_').replace('.', '_')}_simple_state"
+        entity_id = initial_entity_id.replace('_@_', '_')
+        for attempt in range(max_retries):
+            sensor_state = self.hass.states.get(entity_id)
+            if sensor_state:
+                async_track_state_change(self.hass, entity_id, self._on_simple_state_status)
+                return
+            await asyncio.sleep(1)
+
+    def on_pipeline_event(self, event: PipelineEvent):
+        """Handle pipeline events to manage the switch state."""
+
+        # If STT_START is detected, start a task to monitor for STT_VAD_START or ERROR.
+        if event.type == PipelineEventType.STT_START and self._attr_is_on:
+            _LOGGER.debug("Detected STT_START event. Starting monitoring.")
+            asyncio.create_task(self._monitor_vad_start())
+
+        # If STT_VAD_START is detected, set the event flag.
+        if event.type == PipelineEventType.STT_VAD_START:
+            _LOGGER.debug("Detected STT_VAD_START event.")
+            self._vad_start_detected.set()
+
+    async def _monitor_vad_start(self):
+        """Monitor for STT_VAD_START or ERROR within a specified window."""
+        self._vad_start_detected.clear()  # Clear the VAD_START event flag.
+        error_detected = asyncio.Event()  # Create a new event for ERROR detection.
+
+        def handle_error_event(event: PipelineEvent):
+            """Handle the detection of an ERROR event."""
+            if event.type == PipelineEventType.ERROR:
+                _LOGGER.debug("Detected ERROR event. Updating pipeline stage to WAKE_WORD immediately.")
+                error_detected.set()
+
+        # Listen for ERROR events in parallel with the wait.
+        self.hass.bus.async_listen_once("pipeline_event", handle_error_event)
+
+        try:
+            # Create tasks for monitoring STT_VAD_START and ERROR.
+            vad_task = asyncio.create_task(self._vad_start_detected.wait())
+            error_task = asyncio.create_task(error_detected.wait())
+
+            # Wait for either STT_VAD_START or ERROR to occur within the timeout.
+            done, pending = await asyncio.wait(
+                [vad_task, error_task],
+                timeout=9,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            # Cancel pending tasks to avoid resource leaks.
+            for task in pending:
+                task.cancel()
+
+            if error_task in done:
+                # If an ERROR event was detected, update to WAKE_WORD and exit.
+                self._update_pipeline_stage(PipelineStage.WAKE_WORD)
+            elif vad_task in done:
+                # If STT_VAD_START was detected, update to STT.
+                _LOGGER.debug("STT_VAD_START detected within the timeout. Updating pipeline stage to STT.")
+                self._update_pipeline_stage(PipelineStage.STT)
+            else:
+                # If nothing happened within the timeout, update to WAKE_WORD.
+                _LOGGER.debug("No relevant event detected within the timeout. Updating pipeline stage to WAKE_WORD.")
+                self._update_pipeline_stage(PipelineStage.WAKE_WORD)
+        except asyncio.TimeoutError:
+            _LOGGER.debug("Timeout occurred. Updating pipeline stage to WAKE_WORD.")
+            self._update_pipeline_stage(PipelineStage.WAKE_WORD)
+
+
+    def _update_pipeline_stage(self, stage: str):
+        """Update the pipeline stage."""
+        self.hass.data["pipeline_start_stage"] = stage
+
+    async def async_turn_on(self, **kwargs):
+        """Turn on the switch."""
+        self._attr_is_on = True
+        self._update_pipeline_stage(PipelineStage.STT)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn off the switch."""
+        self._attr_is_on = False
+        self._update_pipeline_stage(PipelineStage.WAKE_WORD)
+        self.async_write_ha_state()
+
+    async def async_update(self):
+        """Ensure pipeline stage is updated if the switch is off."""
+        if not self._attr_is_on:
+            self._update_pipeline_stage(PipelineStage.WAKE_WORD)
+
+    async def _on_simple_state_status(self, entity_id: str, old_state: State, new_state: State):
+        """Handle sensor state change to control the microphone."""
+        if new_state and self._attr_is_on:
+            state = new_state.state
+            if state == "intent-processing":
+                await self.microphone.async_turn_off()
+            if state == "tts-finished":
+                await self.microphone.async_turn_on()
+            elif state == "error-error":
+                self._update_pipeline_stage(PipelineStage.WAKE_WORD)


### PR DESCRIPTION
Hello. Congratulations on what you've been able to do with this integration. In order to be able to properly implement Hassmic integration in the ViewAssist project, I made some changes to the code.
1. **Tts-listening state implementation**
 One of the things needed to use this integration is to be as precise as possible when the tts message actually finishes playing because TTS_END marks when the message is sent to the player and not when it finishes playing. That's why I took this implementation from the [StreamAssist integration](https://github.com/AlexxIT/StreamAssist/issues/31) and looked for the best way to implement it in Hassmic. Practically, when the TTS_END event is executed, the URL of the tts is taken and using mutagen.mp3 to calculate the effective duration of the message. Then in the SimpeState sensor I put a new state tts-finished. 
 2. **Correcting the publication order of stt-speaking, stt-listening, wake_word-listening/stt-listening statuses**
 There is a problem though with the fact that the wake_word-listening state fires before the message finishes playing and at the end it remains as the last state `tts-finished` and not `wake_word-listening`. That's why I modified the code to respect the order of publishing the statuses: `stt-speaking`, `stt-listening`and at the end`wake_word-listening` or `stt-listening`, depending on how the continue conversation switch is set. Practically, I added a delay in the publication of wake_word-listening or stt-listening statuses until the tts message is finished playing. This does not affect the functionality of the satellite in any way because the `Simple state sensor` is just a sensor made especially for the View Assist project. Listening to the wake word starts immediately after TTS-END, but in order for the avatar to remain talking until the end of the message playback, this is necessary.
3. **Continue conversation switch**
I also added a switch to enable continue conversation. Changes must also be made in the `_init_.py` file from the` switch` directory,  in the `pipeline_manager.py` file and add `continue_conversation.py` . To be able to use continuous conversation in Hassmic, a switch can be used to choose where to start the pipeline, from `WAKE-WORD` or from `STT-START`. In the continue_conversatin switch code, you can set how many seconds to wait for the next command until it switches back to wake word detection. From what I noticed, after 9 seconds it is no longer in the listening state and the pipeline resumes from the start.
```
            done, pending = await asyncio.wait(
                [vad_task, error_task],
                timeout=9,
                return_when=asyncio.FIRST_COMPLETED,
            )
 ```
            
 Because `stt-listening` starts before the tts message is finished playing, I made an automation in the `continue_conversation switch` code that mutes the microphone between the `tts-speaking` and `tts-listening` statuses of the `simple_state sensor`. Because I failed to import the `simple_state sensor` internally in the `continue_conversation switch`, I chose to import it from the home assistant, but I think it would work better if you managed to import it directly from the hassmic integration.
 
 4. **Conversation_id** 
  In pipeline_manager I put `conversation_id=”123456789”` and it works fine with OpenAi to retain conversation history for last 20 messages. Maybe we will think of a logic to generate random ids for `conversation_id` but keep a specific Id in certain situations if we want to retain the history of the conversation. I believe that the satellite, as in our Hassmic case, is the one that generates the `conversation_id` and the Home Assistant pipeline takes the `conversation_id` from the satellite.
 ```
                     ),
                    start_stage=start_stage,  # It uses dynamic logic for the starting stage
                    device_id=self._device.id,
                    conversation_id="123456789",  # Or get this value from a dynamic source
                )
  ```
  
5. **Custom responses blueprint**
 Optionally  you can use uith that the `custom_responses blueprint` which gives an answer after detecting the wake word (Ex: yes i'm listening) or if you say `ok nabu` twice or when it is in `continue_conversation mode` and you don't realize that the satellite is actually waiting for the command and not the wake word.
```
blueprint:
  name: Viewassist Custom Responses
  description: Automation for custom responses in Viewassist with selectable media content ID, media player, microphone, and custom wake words.
  domain: automation
  input:
    trigger_entity:
      name: Trigger Entity
      description: Microphone entity sensor of satellite ex. sensor.viewassist_office_simple_state
      selector:
        entity:
          domain: sensor
    media_player:
      name: Media Player
      description: Select the media player to use
      selector:
        entity:
          domain: media_player
    microphone_switch:
      name: Microphone Switch
      description: Select the microphone switch to turn off and on
      selector:
        entity:
          domain: switch
    media_content_id:
      name: Media Content ID
      description: The media content ID to play (optional, with a default message)
      default: "media-source://tts/edge_tts?message={{ ['how can I help you', 'yes, i`m listening', 'how can assist you'] | random }}&language=en-US-ChristopherNeural"
      selector:
        text: {}
    custom_wake_words:
      name: Custom Wake Words
      description: Add custom wake words (e.g., 'ok nabu'). Add multiple values if needed.
      default: ["ok nabu", "ok naboo", "okay naboo"]
      selector:
        object: {}
    conversation_response:
      name: Set Conversation Response
      description: The response text for custom wake words
      default: "say please"
      selector:
        text: {}

trigger:
  - platform: state
    entity_id: !input "trigger_entity"
    to: wake_word-detected
    id: wake_word_detected
  - platform: conversation
    command: !input "custom_wake_words"
    id: custom_wake_word_detected

condition: []

action:
  - choose:
      - conditions:
          - condition: trigger
            id: wake_word_detected
        sequence:
          - service: switch.turn_off
            target:
              entity_id: !input "microphone_switch"
          - service: media_player.play_media
            target:
              entity_id: !input "media_player"
            data:
              media_content_id: !input "media_content_id"
              media_content_type: provider
              announce: true
          - wait_for_trigger:
              - platform: state
                entity_id: !input "media_player"
                to: idle
            timeout:
              hours: 0
              minutes: 0
              seconds: 1
              milliseconds: 500
          - service: switch.turn_on
            target:
              entity_id: !input "microphone_switch"
      - conditions:
          - condition: trigger
            id: custom_wake_word_detected
        sequence:
          - service: media_player.play_media
            target:
              entity_id: !input "media_player"
            data:
              media_content_id: !input "media_content_id"
              media_content_type: provider
              announce: true
          - set_conversation_response: !input "conversation_response"
            enabled: true

mode: single
```