### PR TITLE
Global imports changed to explicit imports.

### DIFF
--- a/custom_components/hassmic/connection_manager.py
+++ b/custom_components/hassmic/connection_manager.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .exceptions import BadMessageException
-from .proto.hassmic import *
+from .proto.hassmic import ClientEvent, HassmicCommand, betterproto
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/hassmic/hassmic.py
+++ b/custom_components/hassmic/hassmic.py
@@ -20,7 +20,7 @@ from .connection_manager import ConnectionManager
 from .exceptions import BadHassMicClientInfoException, BadMessageException
 from .const import DOMAIN
 
-from .proto.hassmic import *
+from .proto.hassmic import ClientEvent, ClientInfo, ClientMessage, LogSeverity, SavedSettings, betterproto
 
 MAX_CHUNK_SIZE = 8192
 MAX_JSON_SIZE = 1024

--- a/custom_components/hassmic/media_player/player.py
+++ b/custom_components/hassmic/media_player/player.py
@@ -6,7 +6,16 @@ import logging
 import betterproto
 
 from homeassistant.components import media_source
-from homeassistant.components.media_player import *
+
+from homeassistant.components.media_player import (
+    ENTITY_ID_FORMAT,
+    MediaPlayerEnqueue,
+    MediaPlayerEntity,
+    MediaPlayerEntityDescription,
+    MediaPlayerDeviceClass,
+    MediaPlayerEntityFeature,
+    MediaPlayerState,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.network import NoURLAvailableError, get_url

--- a/custom_components/hassmic/sensor/base.py
+++ b/custom_components/hassmic/sensor/base.py
@@ -7,7 +7,7 @@ import logging
 from homeassistant.components.assist_pipeline.pipeline import (
     PipelineEvent,
 )
-from ..proto.hassmic import *
+from ..proto.hassmic import ClientEvent, betterproto
 from homeassistant.components.sensor import ENTITY_ID_FORMAT, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_IDLE

--- a/custom_components/hassmic/sensor/stt.py
+++ b/custom_components/hassmic/sensor/stt.py
@@ -7,7 +7,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from . import base
-from ..proto.hassmic import *
+from ..proto.hassmic import ClientEvent, betterproto
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/hassmic/switch/microphone.py
+++ b/custom_components/hassmic/switch/microphone.py
@@ -5,7 +5,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from ..proto.hassmic import *
+from ..proto.hassmic import HassmicCommand
 from . import base
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
Changes the various global imports (`from ... import *`)  to explicit imports rather than global. For example:

`from ..proto.hassmic import HassmicCommand` rather than `from ..proto.hassmic import *`

This eliminates the various deprecation notices in the logs ~, and, so far, seems to have eliminated the frequent disconnections. Not sure why those would be affected, but in limited testing, they seem gone~*.

*They're back.

I've left these commits unsquashed for review, but this is a good candidate for `squash and merge` if you accept these changes. 🤠 